### PR TITLE
Update vagrant box + fix apt package upgrades on first provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure(2) do |config|
   config.vm.box = "debian/contrib-jessie64"
-	config.vm.box_version = "8.5.0"
+	config.vm.box_version = "8.7.0"
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -2,7 +2,7 @@
 - hosts: default
   become: true
   tasks:
-    - name: create /opt/first_apt_cache_update_done
+    - name: update apt && upgrade packages
       copy:   dest=/opt/first_apt_cache_update_done content="" force=no
       notify: upgrade packages
       # Upgrade packages on first provisioning, but not later.

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -2,12 +2,20 @@
 - hosts: default
   become: true
   tasks:
-    #- name: upgrade packages
-    #  apt: update_cache=yes upgrade=safe
+    - name: create /opt/first_apt_cache_update_done
+      copy:   dest=/opt/first_apt_cache_update_done content="" force=no
+      notify: upgrade packages
+      # Upgrade packages on first provisioning, but not later.
+      # If you want packages to be upgraded later,
+      # delete /opt/first_apt_cache_update_done and re-provision.
     - name: reconfigure locales
       template: src=locale.gen.j2 dest=/etc/locale.gen owner=root group=root
       notify: re-generate locales
       # correct locales are needed for postgres to install properly.
+
+    - meta: flush_handlers
+      # To make sure packages are upgraded before we install more stuff
+
     - name: uninstall exim4
       apt: name=exim4* state=absent
     - name: install php5
@@ -34,3 +42,5 @@
   handlers:
     - name: re-generate locales
       command: /usr/sbin/locale-gen
+    - name: upgrade packages
+      apt: update_cache=yes upgrade=safe


### PR DESCRIPTION
Fixes issue https://github.com/edruid/SnakeDruid/issues/4

Instead of having to un-comment the package upgrade lines in playbook.yml, the package upgrades will be run during the first provisioning. An empty file is created (`/opt/first_apt_cache_update_done`), and if this file already exists, the upgrades will be skipped to make later provisioning fast.

The upgrade to a newer vagrant box reduces the amount of packages needing to be upgraded.